### PR TITLE
Add CCE container image workflow

### DIFF
--- a/.github/workflows/cce.yaml
+++ b/.github/workflows/cce.yaml
@@ -1,0 +1,106 @@
+# a pipeline to create container image on changes to cce.rb file
+name: cce
+on:
+  push:
+    branches:
+      - main
+    paths:
+    - 'cce.rb'
+    - cce/Dockerfile
+    - .github/workflows/cce.yaml
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: stackgenhq/cce
+jobs:
+  build:
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}
+      version: ${{ steps.version.outputs.VERSION }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            tag-suffix: -amd64
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            tag-suffix: -arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            cce
+            cce.rb
+      - name: Get cce version
+        id: version
+        run: |
+          VERSION="$(awk '$1 == "version" { print $2; exit }' cce.rb | tr -d '"')"
+          test -n "$VERSION" || { echo "Error: Failed to extract version from cce.rb"; exit 1; }
+          echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$' || { echo "Error: Extracted version is not valid semver: $VERSION"; exit 1; }
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.VERSION }}
+            type=raw,value=latest
+          flavor: |
+            suffix=${{ matrix.tag-suffix }},onlatest=false
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./cce
+          platforms: ${{ matrix.platform }}
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+          provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |-
+            CCE_VERSION=${{ steps.version.outputs.VERSION }}
+
+  create_manifest:
+    name: Create manifest
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64
+
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }}-arm64

--- a/cce/Dockerfile
+++ b/cce/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine AS download_binary
+
+ARG CCE_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN apk update && \
+    apk add --no-cache curl && \
+    rm -rf /var/cache/apk/*
+
+RUN URL="https://releases.stackgen.com/binaries/cce/v${CCE_VERSION}/cce_${CCE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz" && \
+    curl -fsSL -o cce.tar.gz "$URL" || { echo "Error: failed to download cce from $URL" >&2; exit 1; } && \
+    tar -xzf cce.tar.gz && \
+    test -f cce || { echo "Error: extracted archive does not contain cce binary" >&2; exit 1; } && \
+    mv cce /tmp/cce && \
+    chmod +x /tmp/cce && \
+    rm -f cce.tar.gz
+
+FROM alpine:latest
+
+RUN apk update && \
+    apk add --no-cache ca-certificates git && \
+    rm -rf /var/cache/apk/* && \
+    addgroup -S stackgen && adduser -S stackgen -G stackgen -u 1000 -h /home/stackgen
+
+COPY --from=download_binary --chown=stackgen:stackgen /tmp/cce /usr/local/bin/cce
+
+USER stackgen
+
+WORKDIR /work
+
+ENTRYPOINT ["/usr/local/bin/cce"]
+CMD ["-help"]


### PR DESCRIPTION
## Summary
- Add `cce/Dockerfile` that downloads release binaries from `releases.stackgen.com`
- Add `.github/workflows/cce.yaml` to publish multi-arch images to `ghcr.io/stackgenhq/cce`

Follows the same pattern as `stackgen`, `aiden-runner`, and `logexplorer`. The workflow triggers when `cce.rb` is updated by GoReleaser after a CCE release.

Companion PR: appcd-dev/cce (removes in-repo container build workflow)

## Test plan
- [ ] Merge this PR
- [ ] Manually dispatch or push a no-op `cce.rb` change to trigger the workflow
- [ ] Confirm `ghcr.io/stackgenhq/cce:0.0.4` and `:latest` manifest lists include amd64 and arm64
- [ ] Run `docker run --rm ghcr.io/stackgenhq/cce:latest -help`


Made with [Cursor](https://cursor.com)