### PR TITLE
fix(aiden-runner): use aiden-runner release path in Dockerfile

### DIFF
--- a/aiden-runner/Dockerfile
+++ b/aiden-runner/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update && \
     apk add --no-cache curl && \
     rm -rf /var/cache/apk/*
 
-RUN URL="https://releases.stackgen.com/binaries/aios-remote/v${AIDEN_RUNNER_VERSION}/aiden-runner_${AIDEN_RUNNER_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz" && \
+RUN URL="https://releases.stackgen.com/binaries/aiden-runner/v${AIDEN_RUNNER_VERSION}/aiden-runner_${AIDEN_RUNNER_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz" && \
     curl -fsSL -o aiden-runner.tar.gz "$URL" || { echo "Error: failed to download aiden-runner from $URL" >&2; exit 1; } && \
     tar -xzf aiden-runner.tar.gz && \
     test -f aiden-runner || { echo "Error: extracted archive does not contain aiden-runner binary" >&2; exit 1; } && \


### PR DESCRIPTION
## Summary

- Fix the `aiden-runner` Docker image build failing with HTTP 403 when downloading release tarballs.
- The Dockerfile still pointed at `binaries/aios-remote/`, but releases have been published under `binaries/aiden-runner/` since v0.1.28 (matching `aiden-runner.rb`).

## Root cause

The `aiden-runner` workflow builds container images by downloading the published tarball in `aiden-runner/Dockerfile`. Since v0.1.28, that download returns 403 because the path changed:

| Path | v0.1.27 | v0.1.28+ |
|------|---------|----------|
| `binaries/aios-remote/...` | 200 | 403 |
| `binaries/aiden-runner/...` | 403 | 200 |

This explains why workflow runs succeeded through v0.1.27 and have failed on every release since.

## Test plan

- [ ] Merge PR and confirm the `aiden-runner` workflow succeeds on the next push to `aiden-runner/Dockerfile` (or manually re-run the failed workflow after merge)
- [ ] Verify multi-arch images are published: `ghcr.io/stackgenhq/aiden-runner:0.1.44-amd64` / `-arm64` and manifest tags `latest` / `0.1.44`


Made with [Cursor](https://cursor.com)