### PR TITLE
OPS-1211: add Docker image publishing for terraform-importer

### DIFF
--- a/.github/workflows/terraform-importer.yaml
+++ b/.github/workflows/terraform-importer.yaml
@@ -1,0 +1,103 @@
+# a pipeline to create container image on changes to terraform-importer.rb file
+name: terraform-importer
+on:
+  push:
+    branches:
+      - main
+    paths:
+    - 'terraform-importer.rb'
+    - terraform-importer/Dockerfile
+    - .github/workflows/terraform-importer.yaml
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: stackgenhq/terraform-importer
+jobs:
+  build:
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}
+      version: ${{ steps.version.outputs.VERSION }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            tag-suffix: -amd
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            tag-suffix: -arm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            terraform-importer
+            terraform-importer.rb
+      - name: Get terraform-importer version
+        id: version
+        run: |
+          echo "VERSION=$(grep 'version' terraform-importer.rb | awk '{print $NF}' | tr -d '"')" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.VERSION }}
+            type=raw,value=latest
+          flavor: |
+            suffix=${{ matrix.tag-suffix }},onlatest=false
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./terraform-importer
+          platforms: ${{ matrix.platform }}
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+          provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |-
+            TERRAFORM_IMPORTER_VERSION=${{ steps.version.outputs.VERSION }}
+
+  create_manifest:
+    name: Create manifest
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/stackgenhq/terraform-importer:latest \
+            ghcr.io/stackgenhq/terraform-importer:latest-amd \
+            ghcr.io/stackgenhq/terraform-importer:latest-arm
+
+          docker buildx imagetools create \
+            -t ghcr.io/stackgenhq/terraform-importer:${{ needs.build.outputs.version }} \
+            ghcr.io/stackgenhq/terraform-importer:${{ needs.build.outputs.version }}-amd \
+            ghcr.io/stackgenhq/terraform-importer:${{ needs.build.outputs.version }}-arm

--- a/terraform-importer/Dockerfile
+++ b/terraform-importer/Dockerfile
@@ -1,0 +1,30 @@
+FROM alpine AS download_binary
+
+ARG TERRAFORM_IMPORTER_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+
+# install wget
+RUN apk update && \
+    apk add --no-cache wget && \
+    rm -rf /var/cache/apk/*
+
+RUN wget -O terraform-importer.tar.gz \
+    https://releases.stackgen.com/binaries/v${TERRAFORM_IMPORTER_VERSION}/terraform-importer-cli_${TERRAFORM_IMPORTER_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz && \
+    tar -xzf terraform-importer.tar.gz && \
+    mv terraform-importer /tmp/terraform-importer
+
+FROM alpine:latest
+
+RUN apk update && \
+    apk add --no-cache ca-certificates && \
+    rm -rf /var/cache/apk/* && \
+    addgroup -S stackgen && adduser -S stackgen -G stackgen -u 1000 -h /home/stackgen
+
+USER stackgen
+
+COPY --from=download_binary --chown=stackgen:stackgen /tmp/terraform-importer /usr/local/bin/terraform-importer
+
+RUN chmod +x /usr/local/bin/terraform-importer
+
+ENTRYPOINT ["/usr/local/bin/terraform-importer"]


### PR DESCRIPTION
## Summary
- Add `terraform-importer/Dockerfile` to package the CLI binary from `releases.stackgen.com`
- Add GitHub Actions workflow to publish multi-arch images to `ghcr.io/stackgenhq/terraform-importer` when `terraform-importer.rb` changes

